### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
   def index
     @items = Item.includes(:user).order('created_at DESC')
   end
@@ -32,6 +32,15 @@ class ItemsController < ApplicationController
       render 'edit'
     end
 
+  end
+
+  def destroy
+    if @item.user_id == current_user.id
+      @item.destroy
+      redirect_to root_path
+      else
+        redirect_to root_path
+      end
   end
 
   private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
     <% if current_user.id == @item.user_id %> 
     <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <%= link_to "削除", item_path(@item), method: :delete, class:"item-destroy" %>
     <%# link_to "売り切れました",item_path(@item),class:"disabled-button bold" %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <% else %>


### PR DESCRIPTION
#What 
商品削除機能
#Why
商品を削除するため

[「ログイン状態の場合にのみ、自身が出品した商品情報を削除できること」とは、詳細ページにおける「削除」ボタンの表示・非表示に加え、コントローラー側でも条件を設けることを指す。](https://gyazo.com/3455c80429468fc5fc6e18fa6a664bbe)